### PR TITLE
Fix for function declaration with spaces

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -241,6 +241,8 @@ class HeaderGenerator(pycparser.c_generator.CGenerator):
                 re.search(
                     (
                         re.escape(result)
+                        .replace("\\(", "\\(\\s*")
+                        .replace("\\)", "\\s*\\)")
                         .replace("\\*", "\\*\\s*")
                         .replace("\\ ", "\\s*")
                         + "\\s*\\{"


### PR DESCRIPTION
fix if a function name is like add( int a, int b ); compared to add(int a, int b);